### PR TITLE
Fitness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ Thumbs.db
 
 # vscode
 .vscode/
+
+# venv
+venv-pokemon/

--- a/src/p2lab/genetic/fitness.py
+++ b/src/p2lab/genetic/fitness.py
@@ -17,16 +17,13 @@ def BTmodel(
     in sports contests.
 
     They do this by assuming that the probability of team 1 beating team 1
-    has the following form:total
+    has the following form:
 
     Pr(team1>team2) = exp(a_1) / (exp(a_1) + exp(a_2))
 
     Where a_1 is team 1's latent ability.
 
-    The abilities are estimated as parameters of a logit model with the
-    following form:
-
-    logit(Pr(team1_wins)) = a_1 - a_2
+    The abilities are estimated via an iterative algorithm.
 
     Which means we only need access to win/loss data and match data in order
     to produce estimates

--- a/src/p2lab/genetic/fitness.py
+++ b/src/p2lab/genetic/fitness.py
@@ -8,38 +8,207 @@ from p2lab.pokemon.team import Team
 def BTmodel(
     teams: list[Team],
     matches: np.ndarray,
-    results: list[int],
+    results: np.ndarray,
+    max_iter: int,
+    tol: float,
 ) -> list[float]:
     """
-    Bradley-Terry Models
+    Bradley-Terry Models are used to estimate latent team 'abilities'
+    in sports contests.
+
+    They do this by assuming that the probability of team 1 beating team 1
+    has the following form:total
+
+    Pr(team1>team2) = exp(a_1) / (exp(a_1) + exp(a_2))
+
+    Where a_1 is team 1's latent ability.
+
+    The abilities are estimated as parameters of a logit model with the
+    following form:
+
+    logit(Pr(team1_wins)) = a_1 - a_2
+
+    Which means we only need access to win/loss data and match data in order
+    to produce estimates
 
     Args:
-        teams: A list of unique team names
+        teams: A list of teams. Used mainly for generating team IDs
         matches: A numpy.ndarray with the following format:
 
-        team 1 | team 2
-        -------+-------
-          A    |   B
-          B    |   C
-          B    |   D
-          A    |   D
-          B    |   A
+            team 1 | team 2
+            -------+-------
+              A    |   B
+              B    |   C
+              B    |   D
+              A    |   D
+              B    |   A
 
-        'team 1' and 'team 2' are columns containing the IDs of the teams
-        that played in the role of team 1 and team 2 respectively
-
-        results: A list of 1s and 0s, where each entry corresponds to a row
-        in matches denoting whether or not team 1 won the match
+                 'team 1' and 'team 2' are columns containing the IDs of the teams
+                 that played in the role of team 1 and team 2 respectively
+        results: An array of 1s and 0s, where each entry corresponds to a row
+                 in matches denoting whether or not team 1 won the match
+        max_iter: Maximum number of iterations for Bradley-Terry model to run
+        tol: Tolerence to check for convergence at the end of each iteration
     """
 
     # Organise teams into X1 and X2 matrices
-    print(teams)
+    N_team = len(teams)
+    N_match = matches.shape[0]
+    team_ids = np.array(range(N_team))
+    X1 = np.zeros(shape=(N_match, N_team), dtype=np.int32)
+    X2 = np.zeros(shape=(N_match, N_team), dtype=np.int32)
+    for index, pair in enumerate(matches):
+        X1[index, pair[0]] = 1
+        X2[index, pair[1]] = 1
+
+    # Prepare win data
+    total_wins = count_team_wins(
+        team_ids=team_ids,
+        matches=matches,
+        results=results,
+    )
+    win_matrix = make_win_matrix(
+        N_team=N_team,
+        matches=matches,
+        results=results,
+    )
 
     # Generate vector of team abilities
-    print(matches)
+    abilities = np.ones(shape=(N_team), dtype=np.float64)
 
-    # Estimate logit model
-    print(results)
+    # Iteratively update abilities as: p_i = W_i / sum_(j!=1) {(w_ij + w_ji)/(p_i + p_j)}
+    for _iter in range(max_iter):
+        old_abilities = abilities
+        abilities = total_wins / np.array(
+            [BT_iter_func(x, team_ids, win_matrix, abilities) for x in team_ids]
+        )
+        abilities = abilities / np.sum(abilities)
 
-    # Return parameters as a measure of fitness
-    return [0.1, 0.2, 0.3]
+        # Check for convergence
+        if np.sum(np.abs(old_abilities - abilities)) < tol:
+            break
+
+    return abilities
+
+
+def BT_iter_func(
+    id: int,
+    team_ids: np.ndarray,
+    win_matrix: np.ndarray,
+    abilities: np.ndarray,
+):
+    """
+    Function to compute this part of the BT iterative estimation:
+    sum_(j!=1) {(w_ij + w_ji)/(p_i + p_j)}
+
+    Args:
+        id: Team to compute the relevant sum for
+        team_ids: Array of all team ids
+        win_matrix: Matrix of wins
+        abilities: Array of abilities
+    """
+    other_ids = team_ids[team_ids != id]
+    return np.sum(
+        (win_matrix[id, other_ids] + win_matrix[other_ids, id])
+        / (abilities[0] + abilities[other_ids])
+    )
+
+
+def win_percentages(
+    teams: list[Team],
+    matches: np.ndarray,
+    results: np.ndarray,
+) -> np.ndarray:
+    """
+    This function calculates the ratio of games won to games played for each
+    team. This serves as a candidate measure for fitness in the genetic algo
+
+    Args:
+        teams: A list of teams. Used mainly for generating team IDs
+        matches: A numpy.ndarray with the following format:
+
+            team 1 | team 2
+            -------+-------
+              A    |   B
+              B    |   C
+              B    |   D
+              A    |   D
+              B    |   A
+
+                 'team 1' and 'team 2' are columns containing the IDs of the teams
+                 that played in the role of team 1 and team 2 respectively
+        results: An array of 1s and 0s, where each entry corresponds to a row
+                 in matches denoting whether or not team 1 won the match
+    """
+    team_ids = np.array(range(len(teams)))
+    total_wins = count_team_wins(
+        team_ids=team_ids,
+        matches=matches,
+        results=results,
+    )
+    total_matches = count_team_matches(
+        team_ids=team_ids,
+        matches=matches,
+    )
+    return total_wins / total_matches
+
+
+# Some helper functions for use across different candidate fitness functions:
+def count_team_wins(
+    team_ids: np.ndarray,
+    matches: np.ndarray,
+    results: np.ndarray,
+) -> np.ndarray:
+    """
+    Given some matches and results, computes total wins for each team
+
+    Args:
+        team_ids:
+        matches (_type_): _description_
+        results:
+    """
+    total_wins = np.array([], dtype=np.int32)
+    for id in team_ids:
+        total_wins = np.append(
+            total_wins,
+            np.sum(results[matches[:, 0] == id])
+            + np.sum(1 - results[matches[:, 1] == id]),
+        )
+    return total_wins
+
+
+def count_team_matches(
+    team_ids: np.ndarray,
+    matches: np.ndarray,
+) -> np.ndarray:
+    """
+    Count the number of matches each team has played
+
+    Args:
+        team_ids:
+        matches (_type_): _description_
+    """
+    return np.array([np.sum(matches == x) for x in team_ids])
+
+
+def make_win_matrix(
+    N_team: int,
+    matches: np.ndarray,
+    results: np.ndarray,
+) -> np.ndarray:
+    """
+    Produces an N_team x N_team matrix, where row (i,j) counts
+    the number of times team i has beaten team j.
+
+    Args:
+        matches (_type_): _description_
+        results (_type_): _description_
+    """
+
+    win_matrix = np.zeros(shape=(N_team, N_team), dtype=np.int32)
+    for index, match in enumerate(matches):
+        if results[index] == 0:
+            win_matrix[match[1], match[0]] += 1
+        else:
+            win_matrix[match[0], match[1]] += 1
+    return win_matrix

--- a/src/p2lab/genetic/genetic.py
+++ b/src/p2lab/genetic/genetic.py
@@ -17,7 +17,8 @@ def genetic_team(
     num_pokemon: int = 6,
     num_teams: int = 100,
     fitness_func: Callable[[list[Team], np.ndarary, list[int]], list[float]] = BTmodel,
-    max_iter: int = 500,
+    max_evolutions: int = 500,
+    **kwargs,
 ) -> None:
     # Generate initial group of teams and matchups
     teams = generate_teams(
@@ -31,10 +32,10 @@ def genetic_team(
     results = run_battles(matches)
 
     # Compute fitness
-    fitness = fitness_func(teams, matches, results)
+    fitness = fitness_func(teams, matches, results, **kwargs)
 
     # Genetic Loop
-    for _iter in range(max_iter):
+    for _iter in range(max_evolutions):
         # Crossover based on fitness func
         new_teams = crossover(teams, fitness, num_teams, num_pokemon)
 
@@ -50,7 +51,7 @@ def genetic_team(
         results = run_battles(matches)
 
         # Compute fitness
-        fitness = fitness_func(teams, matches, results)
+        fitness = fitness_func(teams, matches, results, **kwargs)
 
 
 # Placeholders:

--- a/src/p2lab/pokemon/battle.py
+++ b/src/p2lab/pokemon/battle.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 
-def run_battles(matches: np.ndarray) -> list[int]:
+def run_battles(matches: np.ndarray) -> np.ndarray:
     """
     Runs several matches.
 
@@ -18,12 +18,12 @@ def run_battles(matches: np.ndarray) -> list[int]:
     Returns:
         _type_: _description_
     """
-    results = []
+    results = np.ndarray([])
     for match in matches:
-        results.append(run_battle(match))
+        results = np.append(results, run_battle(match))
     return results
 
 
 def run_battle(match: np.ndarray) -> int:
     print(match)  # delete this line, it's here to pass pre-commit
-    return 0  # this function should always run 0 or 1
+    return 0  # this function should always return 0 or 1


### PR DESCRIPTION
This PR implements two candidate functions for the concept of 'fitness' in the genetic algorithm, both in src/genetic/fitness.py

They are:

- BTmodel(): implements the Bradley-Terry model with an iterative estimation procedure summarised here: https://en.wikipedia.org/wiki/Bradley%E2%80%93Terry_model
  - I had initially thought this would need to be estimated via a logit model, but this seems like a nicer solution
  - The advantage of this model is that even if all teams don't face all teams, so long as we have a good number of matches (and teams are reasonably well-connected to each other in a graph structure) then it should take into account e.g. a team facing only strong teams
  - Because of the way this has been computed, all fitness values will sum to 1
 - win_percentages(): Implements a the ratio of matches a team has won to matches a team has played
   - Nice and straightforward
   - Results will however need normalising - this could be added as a parameter to the function
 - Some stuff renamed in the genetic algorithm psuedocode to avoid clashes in argument names