### PR TITLE
Operations

### DIFF
--- a/src/p2lab/__main__.py
+++ b/src/p2lab/__main__.py
@@ -1,26 +1,29 @@
 """
 TODO: Write some docs here.
 """
+from __future__ import annotations
 
-from .teams.builder import Builder
 from .evaluator.poke_env import PokeEnv
-from tqdm import tqdm
-N_generations = 10 # Number of generations to run
-N_teams = 3 # Number of teams to generate per generation
+from .teams.builder import Builder
+
+N_generations = 10  # Number of generations to run
+N_teams = 3  # Number of teams to generate per generation
+
 
 def main():
     builder = Builder(N_seed_teams=N_teams)
     builder.build_N_teams_from_poke_pool(N_teams)
-    curr_gen = 0 # Current generation
+    curr_gen = 0  # Current generation
     teams = [builder.yield_team() for n in range(N_teams)]
     evaluator = PokeEnv()
     # Main expected loop
     while curr_gen < N_generations:
         team_fitness = evaluator.evaluate_teams(teams)
-        
-        poke_pool = [] # List of Pokemon 
-        teams = [] # list of teams (of Pokemon)
+
+        poke_pool = []  # List of Pokemon
+        teams = []  # list of teams (of Pokemon)
         curr_gen += 1
+
 
 if __name__ == "__main__":
     main()

--- a/src/p2lab/__main__.py
+++ b/src/p2lab/__main__.py
@@ -17,12 +17,12 @@ def main():
     teams = [builder.yield_team() for n in range(N_teams)]
     evaluator = PokeEnv()
     # Main expected loop
-    while curr_gen < N_generations:
-        team_fitness = evaluator.evaluate_teams(teams)
+    # while curr_gen < N_generations:
+    #     team_fitness = evaluator.evaluate_teams(teams)
 
-        poke_pool = []  # List of Pokemon
-        teams = []  # list of teams (of Pokemon)
-        curr_gen += 1
+    #     poke_pool = []  # List of Pokemon
+    #     teams = []  # list of teams (of Pokemon)
+    #     curr_gen += 1
 
 
 if __name__ == "__main__":

--- a/src/p2lab/evaluator/poke_env.py
+++ b/src/p2lab/evaluator/poke_env.py
@@ -1,5 +1,7 @@
 """
 """
+from __future__ import annotations
+
 
 class PokeEnv:
     def __init__(self):

--- a/src/p2lab/genetic/fitness.py
+++ b/src/p2lab/genetic/fitness.py
@@ -148,8 +148,7 @@ def win_percentages(
         matches=matches,
     )
     win_percentages = total_wins / total_matches
-    fitness = win_percentages / np.sum(win_percentages) #standardise to sum to 1
-    return fitness
+    return win_percentages / np.sum(win_percentages)  # standardise to sum to 1
 
 
 # Some helper functions for use across different candidate fitness functions:

--- a/src/p2lab/genetic/fitness.py
+++ b/src/p2lab/genetic/fitness.py
@@ -147,7 +147,9 @@ def win_percentages(
         team_ids=team_ids,
         matches=matches,
     )
-    return total_wins / total_matches
+    win_percentages = total_wins / total_matches
+    fitness = win_percentages / np.sum(win_percentages) #standardise to sum to 1
+    return fitness
 
 
 # Some helper functions for use across different candidate fitness functions:

--- a/src/p2lab/genetic/genetic.py
+++ b/src/p2lab/genetic/genetic.py
@@ -15,14 +15,57 @@ def genetic_team(
     generate_teams: Callable,
     generate_matches: Callable,
     run_battles: Callable,
-    crossover: Callable,
-    mutate: Callable,
+    crossover_fn: Callable,
     fitness_func: Callable[[list[Team], np.ndarray, list[int]], list[float]] = BTmodel,
     num_pokemon: int = 6,
     num_teams: int = 100,
     max_evolutions: int = 500,
-    **kwargs,
+    fitness_kwargs: dict | None = None,
 ) -> None:
+    """
+    A genetic evolution algorithm for optimising pokemon team selection.
+
+    Users specify the population of pokemon to optimise over, the number of pokemon per
+    team, the number of teams, and the number of evolutions to run.
+
+    Users also need to define a fitness function, a crossover function, crossover and mutation
+    probabilities, and if allowing a random number of pokemon to be crossed/mutated, whether to
+    allow this to be random.
+
+    Users can choose to allow mutation probability to occur inversely to fitness instead of
+    performing a crossover + mutation step if desired.
+
+    Args:
+        pokemon_population: A list of strings containing all valid pokemon names for the population
+        num_pokemon: Number of pokmeon in each team
+        num_teams: Number of pokemon teams to generate
+        fitness_fn: A function to define fitness scores after each round
+        crossover_fn: A function that defines the crossover step in each round. Set to
+                      None if this step should be ignored.
+        crossover_prob: Crossover probability. Chance two teams will be crossed over
+                        in the crossover step, as opposed to simply moving to the next
+                        generation. Defaults to 0.95 as should be high.
+        mutate_prob: Probability each team has of randomly mutating. Defaults to 0.01 as
+                     should be low to avoid sub-optimal solutions.
+        mutate_with_fitness: Instead of optimising by crossover followed by mutation,
+                             instead uses a mutation function defined by fitness scores.
+                             Crossover will not be used as fitness scores are invalid
+                             post-crossover. Defaults to False.
+        mutate_k: Number of genes to randomly mutate. Will be randomly chosen if set to
+                  None.
+        allow_all: When randomly choosing the number of pokemon to crossover and mutate,
+                   determines whether the whole team can be crossed/mutated. Should be set
+                   to true when num_pokemon < 3. Redundant if the number of swaps/
+                   mutations is is not random.
+        num_evolutions: Number of evolutions to run the model for. The more the better.
+    """
+    # Some quick checks
+    assert mutate_with_fitness is True or crossover_fn is not None  # you need one!
+    assert mutate_prob > 0
+    assert mutate_prob < 1
+    assert crossover_prob > 0
+    assert crossover_prob <= 1
+
     # Generate initial group of teams and matchups
     teams = generate_teams(
         pokemon_population,
@@ -35,17 +78,42 @@ def genetic_team(
     results = run_battles(matches)
 
     # Compute fitness
-    fitness = fitness_func(teams, matches, results, **kwargs)
+    fitness = fitness_fn(teams, matches, results, **kwargs)
 
     # Genetic Loop
-    for _iter in range(max_evolutions):
-        # Crossover based on fitness func
-        new_teams = crossover(teams, fitness, num_teams, num_pokemon)
+    for _iter in range(num_evolutions):
+        # If mutating with fitness, skip the crossover step. Otherwise, crossover +
+        # mutate.
+        if mutate_with_fitness:
+            teams = fitness_mutate(
+                teams=teams,
+                num_pokemon=num_pokemon,
+                fitness=fitness,
+                pokemon_population=pokemon_population,
+                allow_all=allow_all,
+                k=mutate_k,
+            )
 
-        # Mutate the new teams
-        teams = mutate(
-            new_teams, p=0.1, pokemon_population=pokemon_population
-        )  # need to parameterise mutation prob
+        else:
+            # Crossover based on fitness func
+            new_teams = crossover_fn(
+                teams=teams,
+                fitness=fitness,
+                num_teams=num_teams,
+                num_pokemon=num_pokemon,
+                crossover_prob=crossover_prob,
+                allow_all=allow_all,
+            )
+
+            # Mutate the new teams
+            teams = mutate(
+                teams=new_teams,
+                num_pokemon=num_pokemon,
+                mutate_prob=mutate_prob,
+                pokemon_population=pokemon_population,
+                allow_all=allow_all,
+                k=mutate_k,
+            )
 
         # Generate matches from list of teams
         matches = generate_matches(teams)
@@ -54,4 +122,6 @@ def genetic_team(
         results = run_battles(matches)
 
         # Compute fitness
+        if fitness_kwargs is None:
+            fitness_kwargs = {}
         fitness = fitness_func(teams, matches, results, **kwargs)

--- a/src/p2lab/genetic/operations.py
+++ b/src/p2lab/genetic/operations.py
@@ -29,6 +29,7 @@ def build_crossover_fn(
         num_teams: int,
         num_pokemon: int,
         crossover_prob: float,
+        allow_all: bool = False,
     ) -> list[Team]:
         """
         A crossover function.
@@ -42,6 +43,8 @@ def build_crossover_fn(
             crossover_prob: The crossover probability. Defines the chance at
                             which two teams are crossed over instead of simply
                             being kept. Should be reasonably high
+            allow_all: Allows all members of a team to be crossed over when randomly
+                       choosing the number. Should be True if num_pokemon is < 3.
         """
 
         # Output vector
@@ -70,6 +73,7 @@ def build_crossover_fn(
                     team1=team1_pokemon,
                     team2=team2_pokemon,
                     num_pokemon=num_pokemon,
+                    allow_all=allow_all,
                     **kwargs,
                 )
 
@@ -95,6 +99,7 @@ def locus_swap(
     team1: list[str],
     team2: list[str],
     num_pokemon: int,
+    allow_all: bool,
     locus: int = None,
 ) -> tuple(list[str], list[str]):
     """
@@ -109,12 +114,17 @@ def locus_swap(
         team1: List of pokemon in team 1
         team2: List of pokemon in team 2
         num_pokemon: Number of pokemon in each team
+        allow_all: Whether to allow all pokemon to be swapped when ranomly
+                   choosing the locus point.
         locus: Locus point at which to perform swaps
     """
 
-    # If locus has not been chosen, choose
+    # If locus has not been chosen, randomly choose
     if locus is None:
-        locus = random.sample(range(1, num_pokemon - 1), k=1)[0]
+        # If allow_all is true, the teams may just completely swap members
+        # or not swap at all. This changes the higher level crossover probs!
+        n = 0 if allow_all else 1
+        locus = random.sample(range(n, num_pokemon - n), k=1)[0]
 
     # Check validity of locus
     assert locus > 0
@@ -137,6 +147,7 @@ def slot_swap(
     team1: list[str],
     team2: list[str],
     num_pokemon: int,
+    allow_all: bool,
     k: int = None,
 ) -> tuple(list[str], list[str]):
     """
@@ -151,12 +162,17 @@ def slot_swap(
         team1: List of pokemon in team 1
         team2: List of pokemon in team 2
         num_pokemon: Number of pokemon in each team
+        allow_all: Whether to allow all pokemon to be swapped when ranomly
+                   choosing the value of k.
         k: Number of slots in which to switch pokemon
     """
 
     # If locus has not been chosen, choose
     if k is None:
-        k = random.sample(range(1, num_pokemon - 1), k=1)[0]
+        # If allow_all is true, the teams may just completely swap members
+        # or not swap at all. This changes the higher level crossover probs!
+        n = 0 if allow_all else 1
+        k = random.sample(range(n, num_pokemon - n), k=1)[0]
 
     # Check validity of locus
     assert k > 0
@@ -235,8 +251,8 @@ def mutate(
     teams: list[Team],
     num_pokemon: int,
     mutate_prob: float,
-    use_fitnesses: bool,
     pokemon_population: list[str],
+    allow_all: bool,
     k: int = None,
 ):
     """
@@ -248,6 +264,8 @@ def mutate(
         num_pokemon: The number of pokemon in each team
         mutate_prob: Probability of mutation to occur
         pokemon_population: The population of all possible pokemon
+        allow_all: Whether to allow all pokemon to be swapped when ranomly
+                   choosing the locus point.
         k: Number of team members to mutate. If set to None, this number will
            be random.
     """
@@ -256,7 +274,10 @@ def mutate(
         if np.random.choice([True, False], size=None, p=[mutate_prob, 1 - mutate_prob]):
             # If k has not been chosen, choose randomly how many team members to mutate
             if k is None:
-                k = random.sample(range(num_pokemon))[0]
+                # If allow_all is true, the teams may just completely swap members
+                # or not swap at all. This changes the higher level crossover probs!
+                n = 0 if allow_all else 1
+                k = random.sample(range(n, num_pokemon - n))[0]
 
             # Randomly swap k members of the team out with pokemon from the general pop
             mutate_indices = np.random.choice(range(num_pokemon), size=3, replace=False)
@@ -273,6 +294,7 @@ def fitness_mutate(
     num_pokemon: int,
     fitness: np.array,
     pokemon_population: list[str],
+    allow_all: bool,
     k: int = None,
 ):
     """
@@ -287,6 +309,8 @@ def fitness_mutate(
         num_pokemon: The number of pokemon in each team
         fitness: Team fitnesses
         pokemon_population: The population of all possible pokemon
+        allow_all: Whether to allow all pokemon to be swapped when ranomly
+                   choosing the locus point.
         k: Number of team members to mutate. If set to None, this number will
            be random.
     """
@@ -297,7 +321,10 @@ def fitness_mutate(
         ):
             # If k has not been chosen, choose randomly how many team members to mutate
             if k is None:
-                k = random.sample(range(num_pokemon))[0]
+                # If allow_all is true, the teams may just completely swap members
+                # or not swap at all. This changes the higher level crossover probs!
+                n = 0 if allow_all else 1
+                k = random.sample(range(n, num_pokemon - n))[0]
 
             # Randomly swap k members of the team out with pokemon from the general pop
             mutate_indices = np.random.choice(range(num_pokemon), size=3, replace=False)

--- a/src/p2lab/genetic/operations.py
+++ b/src/p2lab/genetic/operations.py
@@ -43,7 +43,7 @@ def build_crossover_fn(
                             which two teams are crossed over instead of simply
                             being kept. Should be reasonably high
         """
-        
+
         # Output vector
         new_teams = []
 
@@ -237,7 +237,7 @@ def mutate(
     mutate_prob: float,
     use_fitnesses: bool,
     pokemon_population: list[str],
-    k:int = None,
+    k: int = None,
 ):
     """
     A mutation operation. At random, k members of a team are swapped with k
@@ -252,19 +252,19 @@ def mutate(
            be random.
     """
     for team in teams:
-        
         # Each team faces a random chance of mutation
-        if np.random.choice([True, False], size=None, p=[mutate_prob,1-mutate_prob]):
-            
+        if np.random.choice([True, False], size=None, p=[mutate_prob, 1 - mutate_prob]):
             # If k has not been chosen, choose randomly how many team members to mutate
             if k is None:
                 k = random.sample(range(num_pokemon))[0]
-            
+
             # Randomly swap k members of the team out with pokemon from the general pop
             mutate_indices = np.random.choice(range(num_pokemon), size=3, replace=False)
-            new_pokemon = np.random.choice(pokemon_population, size=k, replace=True) #open to parameterising the replace
+            new_pokemon = np.random.choice(
+                pokemon_population, size=k, replace=True
+            )  # open to parameterising the replace
             team.pokemon[mutate_indices] = new_pokemon
-    
+
     return teams
 
 
@@ -273,12 +273,12 @@ def fitness_mutate(
     num_pokemon: int,
     fitness: np.array,
     pokemon_population: list[str],
-    k:int = None,
+    k: int = None,
 ):
     """
     A mutation operation. Does the same as regular mutation, except that
     mutate probabilites are now inverse to fitness scores.
-    
+
     Should either be used prior to crossover, or without using any kind of
     crossover.
 
@@ -291,18 +291,19 @@ def fitness_mutate(
            be random.
     """
     for index, team in enumerate(teams):
-        
         # Each team faces a random chance of mutation
-        if np.random.choice([True, False], size=None, p=[1-fitness[index],fitness[index]]):
-            
+        if np.random.choice(
+            [True, False], size=None, p=[1 - fitness[index], fitness[index]]
+        ):
             # If k has not been chosen, choose randomly how many team members to mutate
             if k is None:
                 k = random.sample(range(num_pokemon))[0]
-            
+
             # Randomly swap k members of the team out with pokemon from the general pop
             mutate_indices = np.random.choice(range(num_pokemon), size=3, replace=False)
-            new_pokemon = np.random.choice(pokemon_population, size=k, replace=True) #open to parameterising the replace
+            new_pokemon = np.random.choice(
+                pokemon_population, size=k, replace=True
+            )  # open to parameterising the replace
             team.pokemon[mutate_indices] = new_pokemon
-    
-    return teams
 
+    return teams

--- a/src/p2lab/teams/builder.py
+++ b/src/p2lab/teams/builder.py
@@ -14,6 +14,7 @@ class Builder(Teambuilder):
     """
     The team builder
     """
+
     def __init__(self, N_seed_teams=2, teams=None, format="gen2randombattle"):
         if teams:
             self.teams = [
@@ -22,12 +23,21 @@ class Builder(Teambuilder):
         else:
             self.teams = []
             for _ in range(N_seed_teams):
-                self.teams.append(self.parse_showdown_team(check_output(f"pokemon-showdown generate-team {format}| pokemon-showdown export-team", shell=True).decode(sys.stdout.encoding)))
+                self.teams.append(
+                    self.parse_showdown_team(
+                        check_output(
+                            f"pokemon-showdown generate-team {format}| pokemon-showdown export-team",
+                            shell=True,
+                        ).decode(sys.stdout.encoding)
+                    )
+                )
         self.poke_pool = np.array(self.teams).flatten()
-        
+
     def build_N_teams_from_poke_pool(self, N_teams):
-        self.teams = [np.random.choice(self.poke_pool, size=6, replace=False) for _ in range(N_teams)]
-        
+        self.teams = [
+            np.random.choice(self.poke_pool, size=6, replace=False)
+            for _ in range(N_teams)
+        ]
 
     def yield_team(self):
         return self.teams[np.random.choice(len(self.teams))]


### PR DESCRIPTION
This PR adds the two main genetic operations: crossover and mutation.

Crossover works to preserve good 'genes' (pokemon team mebers) by selecting two 'chromosomes' (teams) (with replacement) in proportion to their fitness, then swapping their 'genes' (pokemon).

Mutation works to maintain 'genetic' diversity (pokemon diversity) by occasionally randomly adding members to the teams and removing old ones.

There's been some discussion about how best to do this, so I've made this code as modular and as flexible as possible.

For crossover:
- Three methods exist.
  - Locus swap picks a point (e.g. 3), then splits both lists in half and recombines their separate halves
  - Slot swap randomly picks indices, then swaps those indices between the two lists. I realised it's essentially equivalent to locus swap as the lists are unordered, but we move ¯\_(ツ)_/¯
  - Sample swap turns the two lists into a population, and then samples from it. Can be done with or without replacement. With replacement is the interesting option (but is still parameterised, as at that point it's going to produce different results to the other two
- A crossover function can be constructed as follows (using locus_swap as an example):
```python
from p2lab.genetic.operations import build_crossover_fn, locus_swap

crossover = build_crossover_fn(crossover_method = locus_swap, locus=3)
```
- the three different crossover methods (`locus_swap`, `slot_swap`, and `sample_swap` all have their own kwargs.


For mutation:
- two mutation functions have been implemented in light of some of the discussions in the team re how to best implement and optimise 1v1, 2v2, 6v6, etc
- the first, mutate, is defined by a global mutation probability
- the second, fitness_mutate, uses the inverse of the fitness scores. I'm not 100% satisfied by this, as as the number of teams increases, the mutation chance for each decreases (although this may be a good thing thinking about it)
- I've updated `genetic_team` in genetic.py to take a crossover function as input, along with some mutation and crossover-related params
- when using fitness_mutate (defined by the `mutate_with_fitness` argument in the `genetic_team` function above), the crossover step will be skipped. This is because post-crossover/mutation, and previous fitness scores will be invalid


I've also updated the `win_percentages` fitness function to standardise the fitnesses to sum to 1.


Some additional thoughts based on some discussion earlier today and in other PRs:

- For 2v2, I suspect having a low crossover probability may be preferable to mutating inversely to the fitness function. Crossovers role is to pass on good genes, but since there's an associated probability of simply passing on the full teams, this will better allow good genes to pass on instead of relying on mutation alone (which is random as to the genes it brings into the population)
- EDIT: the same doesn't hold for 1v1 as obviously crossover stops being meaningful - removed a comment where I thought it did!
  - last edit, but maybe this is worth taking back - 'crossover' here really combines two operators from the literature: selection and crossover. The former means higher fitness increases probability of selection into the next generation. Crossover is the breeding part. We still probably want selection to occur! Will add a selection-only crossover function for this
- I don't think we need all vs all for 1v1 if the BTmodel is used as the fitness function, as the quality of the opponent is taken into account (so long as enough matches occur and all clusters of matches are sufficently connected to each other). This should help to reduce runtime if needed


