### PR TITLE
Change docker image to run the simulation on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ options:
 ### Docker:
 
 Alternatively, using docker: `docker build -t p2:latest docker/`
-`docker run -it p2:latest`
+`docker run -it -v <path-to-config>.yaml:/home/p2lab-pokemon/config.yaml p2`
 
-The docker image is built to start a server and run `p2lab`.
+The docker image is built to start a server and run `p2lab` with the config
+mounted at the root of the repo.
 
 ## Components used
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ options:
 
 ### Docker:
 
-Alternatively, using docker: `docker build -t p2:latest .`
-`docker run -it p2:latest` `docker exec -it your_container_id /bin/bash`
+Alternatively, using docker: `docker build -t p2:latest docker/`
+`docker run -it p2:latest`
 
-Run docker build with `--no-cache` to rebuild with newer versions of the repos.
+The docker image is built to start a server and run `p2lab`.
 
 ## Components used
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,11 @@
+generations: 10 # Number of generations to iterate over
+team_size: 3 # Number of pokemon per team (max 6)
+teams: 30 # Number of teams i.e., individuals per generation
+seed: # Random seed to use
+unique: True # Determines if a team can have duplicate pokemon species
+crossover: # Determines which crossover function to use
+p1: "Player 1" # Name of the first player
+p2: "Player 2" # Name of the second player
+battles_per_match: 3 # Number of battles per match
+write_every: 10 # Write every N generations
+write_path: "./results" # Path to write to

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,4 +24,6 @@ RUN chmod +x $P2_PATH/pokemon-showdown/entrypoint.sh
 
 WORKDIR $P2_PATH/pokemon-showdown
 
+ENV CONFIG_PATH=$P2_PATH/config.yaml
+
 ENTRYPOINT $P2_PATH/pokemon-showdown/entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 from python
 
 RUN apt-get update
-RUN apt-get upgrade
+RUN apt-get upgrade -y
 RUN apt-get install nodejs npm -y
 
 ENV ROOT_DIR=/home
@@ -19,5 +19,9 @@ RUN pip install -e $P2_PATH/poke_env
 
 RUN npm install -g $P2_PATH/pokemon-showdown
 
+COPY ./entrypoint.sh $P2_PATH/pokemon-showdown/entrypoint.sh
+RUN chmod +x $P2_PATH/pokemon-showdown/entrypoint.sh
+
 WORKDIR $P2_PATH/pokemon-showdown
-ENTRYPOINT node pokemon-showdown start --no-security &&
+
+ENTRYPOINT $P2_PATH/pokemon-showdown/entrypoint.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+node pokemon-showdown start --no-security &
+
+while ! curl -I -s 0.0.0.0:8000; do
+  sleep 1
+done
+
+p2lab

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "numpy==1.24.3",
     "networkx",
     "tqdm",
+    "pyyaml",
     "pytest"
 ]
 

--- a/src/p2lab/__main__.py
+++ b/src/p2lab/__main__.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 from pathlib import Path
 
 import numpy as np
+import yaml
 
 from p2lab.genetic.genetic import genetic_algorithm
 from p2lab.genetic.operations import (
@@ -90,6 +92,16 @@ async def main_loop(
     print(f"Fitness: {fitness}")
 
 
+def load_config_file(config_filepath):
+    """
+    Helper function that reads a yaml file and returns its contents as a dict.
+    Args:
+        :param config_filepath: str, a path pointing to the yaml config.
+    """
+    with Path.open(config_filepath) as yaml_config:
+        return yaml.load(yaml_config, Loader=yaml.Loader)
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -153,7 +165,7 @@ def parse_args():
 
 
 def main():
-    args = parse_args()
+    args = load_config_file(os.environ["CONFIG_PATH"])
     if args["seed"] is not None:
         np.random.seed(args["seed"])
 


### PR DESCRIPTION
One less line of commands to run the simulation

Container runs server then checks that server is listening. Then runs p2lab.

The container might have to be changed at some point because the output probably won't be saved anywhere. I'd have to mount some persistent storage and save the simulation results there.

